### PR TITLE
fix wrong tcc config path

### DIFF
--- a/tcc/grpc/cmd/client/main.go
+++ b/tcc/grpc/cmd/client/main.go
@@ -45,7 +45,7 @@ func main() {
 	defer conn.Close()
 	c1, c2 := pb.NewTCCServiceBusiness1Client(conn), pb.NewTCCServiceBusiness2Client(conn)
 
-	client.InitPath("./sample/conf/seatago.yml")
+	client.InitPath("./conf/seatago.yml")
 	tm.WithGlobalTx(
 		context.Background(),
 		&tm.GtxConfig{

--- a/tcc/grpc/cmd/server/main.go
+++ b/tcc/grpc/cmd/server/main.go
@@ -33,7 +33,7 @@ import (
 )
 
 func main() {
-	client.InitPath("./sample/conf/seatago.yml")
+	client.InitPath("./conf/seatago.yml")
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", 50051))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #

**The related PR of seata-go** 


**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.