### PR TITLE
Refactor/urefactor: eliminate hardcoded database DSNs across multiple sample applicationsse util get dsn

### DIFF
--- a/at/gorm/main.go
+++ b/at/gorm/main.go
@@ -19,13 +19,12 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
+	"seata.apache.org/seata-go-samples/util"
 	"seata.apache.org/seata-go/pkg/client"
-	sql2 "seata.apache.org/seata-go/pkg/datasource/sql"
 	"seata.apache.org/seata-go/pkg/tm"
 )
 
@@ -65,11 +64,9 @@ func initConfig() {
 var gormDB *gorm.DB
 
 func initDB() {
-	sqlDB, err := sql.Open(sql2.SeataATMySQLDriver, "root:12345678@tcp(127.0.0.1:3306)/seata_client?multiStatements=true&interpolateParams=true")
-	if err != nil {
-		panic("init service error")
-	}
+	sqlDB := util.GetAtMySqlDb()
 
+	var err error
 	gormDB, err = gorm.Open(mysql.New(mysql.Config{
 		Conn: sqlDB,
 	}), &gorm.Config{})

--- a/at/grpc/service/service.go
+++ b/at/grpc/service/service.go
@@ -25,8 +25,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	__ "seata.apache.org/seata-go-samples/at/grpc/pb"
-
-	sql2 "seata.apache.org/seata-go/pkg/datasource/sql"
+	"seata.apache.org/seata-go-samples/util"
 )
 
 var (
@@ -34,11 +33,7 @@ var (
 )
 
 func InitService() {
-	var err error
-	db, err = sql.Open(sql2.SeataATMySQLDriver, "root:12345678@tcp(127.0.0.1:3306)/seata_client?multiStatements=true&interpolateParams=true")
-	if err != nil {
-		panic("init service error")
-	}
+	db = util.GetAtMySqlDb()
 }
 
 type GrpcBusinessService struct {

--- a/tcc/fence/service/service.go
+++ b/tcc/fence/service/service.go
@@ -19,19 +19,14 @@ package service
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"sync"
 
+	"seata.apache.org/seata-go-samples/util"
 	"seata.apache.org/seata-go/pkg/rm/tcc"
 	"seata.apache.org/seata-go/pkg/rm/tcc/fence"
 	"seata.apache.org/seata-go/pkg/tm"
 	"seata.apache.org/seata-go/pkg/util/log"
-)
-
-const (
-	DriverName = "mysql"
-	Url        = "root:root@tcp(127.0.0.1:3306)/seata?charset=utf8&parseTime=True"
 )
 
 var (
@@ -59,10 +54,7 @@ func NewTestTCCServiceBusinessProxy() *tcc.TCCServiceProxy {
 }
 
 func (T TestTCCServiceBusiness) Prepare(ctx context.Context, params interface{}) (b bool, err error) {
-	db, err := sql.Open(DriverName, Url)
-	if err != nil {
-		return false, fmt.Errorf("database connect failed, msg :%s", err.Error())
-	}
+	db := util.GetTccMySqlDb()
 	defer func() {
 		_ = db.Close()
 	}()
@@ -88,10 +80,7 @@ func (T TestTCCServiceBusiness) Prepare(ctx context.Context, params interface{})
 }
 
 func (T TestTCCServiceBusiness) Commit(ctx context.Context, businessActionContext *tm.BusinessActionContext) (b bool, err error) {
-	db, err := sql.Open(DriverName, Url)
-	if err != nil {
-		return false, fmt.Errorf("database connect failed, msg :%s", err.Error())
-	}
+	db := util.GetTccMySqlDb()
 	defer func() {
 		_ = db.Close()
 	}()
@@ -117,10 +106,7 @@ func (T TestTCCServiceBusiness) Commit(ctx context.Context, businessActionContex
 }
 
 func (T TestTCCServiceBusiness) Rollback(ctx context.Context, businessActionContext *tm.BusinessActionContext) (b bool, err error) {
-	db, err := sql.Open(DriverName, Url)
-	if err != nil {
-		return false, fmt.Errorf("database connect failed, msg :%s", err.Error())
-	}
+	db := util.GetTccMySqlDb()
 	defer func() {
 		_ = db.Close()
 	}()
@@ -169,10 +155,7 @@ func NewTestTCCServiceBusiness2Proxy() *tcc.TCCServiceProxy {
 }
 
 func (T TestTCCServiceBusiness2) Prepare(ctx context.Context, params interface{}) (b bool, err error) {
-	db, err := sql.Open(DriverName, Url)
-	if err != nil {
-		return false, fmt.Errorf("database connect failed, msg :%s", err.Error())
-	}
+	db := util.GetTccMySqlDb()
 	defer func() {
 		_ = db.Close()
 	}()
@@ -198,10 +181,7 @@ func (T TestTCCServiceBusiness2) Prepare(ctx context.Context, params interface{}
 }
 
 func (T TestTCCServiceBusiness2) Commit(ctx context.Context, businessActionContext *tm.BusinessActionContext) (b bool, err error) {
-	db, err := sql.Open(DriverName, Url)
-	if err != nil {
-		return false, fmt.Errorf("database connect failed, msg :%s", err.Error())
-	}
+	db := util.GetTccMySqlDb()
 	defer func() {
 		_ = db.Close()
 	}()
@@ -227,10 +207,7 @@ func (T TestTCCServiceBusiness2) Commit(ctx context.Context, businessActionConte
 }
 
 func (T TestTCCServiceBusiness2) Rollback(ctx context.Context, businessActionContext *tm.BusinessActionContext) (b bool, err error) {
-	db, err := sql.Open(DriverName, Url)
-	if err != nil {
-		return false, fmt.Errorf("database connect failed, msg :%s", err.Error())
-	}
+	db := util.GetTccMySqlDb()
 	defer func() {
 		_ = db.Close()
 	}()

--- a/util/db.go
+++ b/util/db.go
@@ -44,6 +44,16 @@ func GetXAMySqlDb() *sql.DB {
 	return dbAt
 }
 
+func GetTccMySqlDb() *sql.DB {
+	defaultEnv()
+	dsn := os.ExpandEnv("${MYSQL_USERNAME}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DB}?charset=utf8&parseTime=True")
+	dbTcc, err := sql.Open("mysql", dsn)
+	if err != nil {
+		panic("init tcc mysql driver error")
+	}
+	return dbTcc
+}
+
 func defaultEnv() {
 	if os.Getenv("MYSQL_HOST") == "" {
 		_ = os.Setenv("MYSQL_HOST", "127.0.0.1")

--- a/xa/gorm/main.go
+++ b/xa/gorm/main.go
@@ -19,13 +19,12 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
+	"seata.apache.org/seata-go-samples/util"
 	"seata.apache.org/seata-go/pkg/client"
-	sql2 "seata.apache.org/seata-go/pkg/datasource/sql"
 	"seata.apache.org/seata-go/pkg/tm"
 )
 
@@ -72,11 +71,9 @@ func initConfig() {
 var gormDB *gorm.DB
 
 func initDB() {
-	sqlDB, err := sql.Open(sql2.SeataXAMySQLDriver, "root:12345678@tcp(127.0.0.1:3306)/seata_client?multiStatements=true&interpolateParams=true")
-	if err != nil {
-		panic("init service error")
-	}
+	sqlDB := util.GetXAMySqlDb()
 
+	var err error
 	gormDB, err = gorm.Open(mysql.New(mysql.Config{
 		Conn: sqlDB,
 	}), &gorm.Config{})


### PR DESCRIPTION
What this PR does:

* Removes all literal hardcoded database connection strings (DSNs) from `at/gorm`, `at/grpc`, `xa/gorm`, and `tcc/fence` sample applications.
* Replaces them with centralized configuration helpers from the `util` package (`util.GetAtMySqlDb`, `util.GetXaMySqlDb`, and `util.GetTccMySqlDb`) to support dynamic environment variable injection (`MYSQL_HOST`, `MYSQL_PORT`, etc.).
* Restores the complete definition of `util.GetTccMySqlDb` utilizing the standard mysql driver to fix TCC fence dependencies.

Which issue(s) this PR fixes:
Fixes #99

The related PR of seata-go:
N/A

You should pay attention to items below to ensure your pr passes our ci test:
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] Your new-created file needs to have apache license at the top, like other existed file does.